### PR TITLE
Add a daily cronjob to fetch and test deserialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 on:
   push:
+    branch: "main"
   pull_request:
+  merge_group:
 
 name: CI
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,76 @@
+on:
+  push:
+  pull_request:
+
+name: CI
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  RUST_BACKTRACE: short
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
+      - uses: Swatinem/rust-cache@v2
+      - name: Run cargo check
+        run: cargo check --all --all-features
+
+  test_os:
+    name: Tests on ${{ matrix.os }} with Rust ${{ matrix.rust }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        rust: [stable, nightly, 1.85.0]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Run all tests
+        run: cargo test --workspace
+
+  cargo-deny:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v6
+    - uses: EmbarkStudios/cargo-deny-action@v2
+      with:
+        log-level: warn
+        manifest-path: ./Cargo.toml
+        command: check
+        arguments: --all-features
+        command-arguments: ""
+        credentials: https://${{ secrets.GITHUB_USER }}:${{ secrets.GITHUB_PAT }}@github.com
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: Run cargo clippy
+        run: cargo clippy --all --all-targets --all-features -- -D warnings -Wclippy::pedantic

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,7 +2,7 @@ on:
   push:
   pull_request:
 
-name: CI
+name: Daily Tests
 
 env:
   CARGO_INCREMENTAL: 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,7 +1258,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/crates/arch-reflector/Cargo.toml
+++ b/crates/arch-reflector/Cargo.toml
@@ -34,5 +34,8 @@ regex = "1.12"
 tokio = { version = "1.49", features = ["rt-multi-thread", "process", "sync"] }
 tempfile = "3.2"
 
+[dev-dependencies]
+tokio = { version = "1.49", features = ["rt-multi-thread", "macros"] }
+
 [lints]
 workspace = true

--- a/crates/arch-reflector/tests/fetch_test.rs
+++ b/crates/arch-reflector/tests/fetch_test.rs
@@ -1,0 +1,10 @@
+use arch_mirrors_rs::Status;
+
+const URL: &str = "https://archlinux.org/mirrors/status/json/";
+
+// Fetch the latest mirrors and ensure that it deserializes correctly
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn default_mirrors_fetch_test() {
+    let response: Status = reqwest::get(URL).await.unwrap().json().await.unwrap();
+    assert!(!response.urls.is_empty());
+}


### PR DESCRIPTION
As the format might update over time, and a deserialization error will break the tool, this cronjob will run tests daily, and a test to fetch and deserialize the JSON has been added to include in this test suite. The cronjob will file an issue if the build or tests fail. This fixes #2.